### PR TITLE
Add prominent GitHub repository callouts to all project pages

### DIFF
--- a/src/pages/projects/fileinator.md
+++ b/src/pages/projects/fileinator.md
@@ -8,6 +8,14 @@ image: /img/fileinator.webp
 
 ![fileinator](/img/fileinator.webp)
 
+:::info GitHub Repository
+
+📦 **Source Code**: [github.com/JustinBeckwith/fileinator](https://github.com/JustinBeckwith/fileinator)
+
+View the source code, report issues, and contribute to the project.
+
+:::
+
 [![npm version](https://img.shields.io/npm/v/fileinator.svg)](https://www.npmjs.org/package/fileinator)
 [![codecov](https://codecov.io/gh/JustinBeckwith/fileinator/branch/main/graph/badge.svg)](https://codecov.io/gh/JustinBeckwith/fileinator)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)

--- a/src/pages/projects/linkinator-action.md
+++ b/src/pages/projects/linkinator-action.md
@@ -8,6 +8,14 @@ image: /img/linkinator-action.webp
 
 ![linkinator-action](/img/linkinator-action.webp)
 
+:::info GitHub Repository
+
+📦 **Source Code**: [github.com/JustinBeckwith/linkinator-action](https://github.com/JustinBeckwith/linkinator-action)
+
+View the source code, report issues, and contribute to the project.
+
+:::
+
 Linkinator Action brings powerful link validation to your GitHub workflows. Automatically scan markdown files, documentation, and entire websites for broken links during CI/CD, ensuring your links stay healthy across pull requests and deployments.
 
 ## Features

--- a/src/pages/projects/linkinator-mcp.md
+++ b/src/pages/projects/linkinator-mcp.md
@@ -8,6 +8,14 @@ image: /img/linkinator-mcp.webp
 
 ![linkinator-mcp](/img/linkinator-mcp.webp)
 
+:::info GitHub Repository
+
+📦 **Source Code**: [github.com/JustinBeckwith/linkinator-mcp](https://github.com/JustinBeckwith/linkinator-mcp)
+
+View the source code, report issues, and contribute to the project.
+
+:::
+
 [![npm version](https://img.shields.io/npm/v/linkinator-mcp)](https://www.npmjs.com/package/linkinator-mcp)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/JustinBeckwith/linkinator-mcp/blob/main/LICENSE)
 

--- a/src/pages/projects/linkinator.md
+++ b/src/pages/projects/linkinator.md
@@ -31,6 +31,14 @@ image: /img/linkinator.webp
 
 ![linkinator](/img/linkinator.webp)
 
+:::info GitHub Repository
+
+📦 **Source Code**: [github.com/JustinBeckwith/linkinator](https://github.com/JustinBeckwith/linkinator)
+
+View the source code, report issues, and contribute to the project.
+
+:::
+
 [![npm version](https://img.shields.io/npm/v/linkinator)](https://www.npmjs.com/package/linkinator)
 [![codecov](https://img.shields.io/codecov/c/github/JustinBeckwith/linkinator/main)](https://app.codecov.io/gh/JustinBeckwith/linkinator)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)

--- a/src/pages/projects/retry-axios.md
+++ b/src/pages/projects/retry-axios.md
@@ -31,6 +31,14 @@ image: /img/retry-axios.webp
 
 ![retry-axios](/img/retry-axios.webp)
 
+:::info GitHub Repository
+
+📦 **Source Code**: [github.com/JustinBeckwith/retry-axios](https://github.com/JustinBeckwith/retry-axios)
+
+View the source code, report issues, and contribute to the project.
+
+:::
+
 **retry-axios** is a powerful Axios interceptor library that automatically retries failed HTTP requests with intelligent backoff strategies. Whether you're dealing with network errors, rate limiting (429), server errors (5xx), or temporary failures, retry-axios provides flexible retry logic for Axios with built-in exponential backoff, jitter support, and customizable retry strategies.
 
 Perfect for building resilient Node.js applications, this Axios retry plugin helps you handle transient failures gracefully without writing complex retry logic. Add automatic retry capabilities to any Axios instance with just a few lines of code.

--- a/src/pages/projects/twinklyjs.md
+++ b/src/pages/projects/twinklyjs.md
@@ -29,6 +29,14 @@ image: /img/twinkly.webp
 
 ![Twinkly](/img/twinkly.webp)
 
+:::info GitHub Repository
+
+📦 **Source Code**: [github.com/twinklyjs/twinklyjs](https://github.com/twinklyjs/twinklyjs)
+
+View the source code, report issues, and contribute to the project.
+
+:::
+
 **TwinklyJS** is a powerful JavaScript and TypeScript library for controlling Twinkly smart lights with Node.js. This unofficial Twinkly API implementation enables developers to automate Twinkly lights, control colors and effects, discover devices on your network, and integrate Twinkly lights into JavaScript applications. Whether you need a Twinkly Node.js library, a Twinkly CLI tool, or want to build custom Twinkly light automations, twinklyjs provides a complete TypeScript SDK for the Twinkly Lights API.
 
 Perfect for home automation, smart lighting projects, and creative light displays, this Twinkly JavaScript library offers both command-line and programmatic control over your Twinkly smart lights.


### PR DESCRIPTION
## Summary

Added prominent Docusaurus info admonitions with GitHub repository links to all project pages. The callouts are positioned directly under the hero image to make it immediately obvious where users can find the source code, report issues, and contribute.

## Changes

All project pages now feature a blue-highlighted callout box with:
- 📦 GitHub repository link
- Clear call-to-action text

## Projects Updated

- twinklyjs
- fileinator  
- linkinator
- linkinator-action
- linkinator-mcp
- retry-axios

## Test Plan

- [ ] Build the site locally and verify callouts render correctly
- [ ] Check that the info admonitions display with proper styling
- [ ] Verify all GitHub links are correct and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)